### PR TITLE
fixed highlight for document and keyword

### DIFF
--- a/grammars/robottxt.cson
+++ b/grammars/robottxt.cson
@@ -23,9 +23,14 @@
     'name': 'comment.robot'
   }
   {
-    'begin': '^[^ \t\n\*\|].+'
+    'begin': '^[^ \t\n\*\|]\\.+'
     'end': '$'
-    'name': 'keyword.control.robot'
+    'name': 'comment.robot'
+  }
+  {
+      'begin': '(^[^ \\t\\*\\n\\|]+)|((?<=^\\|)\\s+[^ \\t\\*\\n\\|]+)'
+      'end': '\\s{2}|\\t|$|\\s+(?=\\|)'
+      'name': 'keyword.robot'
   }
   {
     'match': '(^\\s+|\\t+)(Given|When|And|Then|But)'


### PR DESCRIPTION
Fixed documentation and start keywords highlight colour.

Before:
<img width="330" alt="before" src="https://cloud.githubusercontent.com/assets/1049251/14183798/4549208a-f79c-11e5-8095-a43b3f559044.png">

After:
<img width="326" alt="after" src="https://cloud.githubusercontent.com/assets/1049251/14183808/4f0efe6e-f79c-11e5-94a1-75b62a882f75.png">
