### PR TITLE
Improved Syntax Highlights

### DIFF
--- a/grammars/robottxt.cson
+++ b/grammars/robottxt.cson
@@ -19,6 +19,9 @@
     'include': '#comment'
   }
   {
+    'include': '#keyword'
+  }
+  {
     'begin': '^(?![ \\t\\n\\*\\|])'
     'contentName': 'keyword.control.robot'
     'end': '\\s{2,}|\\t|$'
@@ -28,16 +31,6 @@
       }
     ]
   }
-  {
-    'begin': '^([ \\t]+)\\$\\{.+?\\=([ \\t]+)'
-    'contentName': 'keyword.control.robot'
-    'end': '\\s{2,}|\\t|$'
-    'patterns': [
-      {
-        'include': '#variables'
-      }
-    ]
-  }  
   {
     'begin': '^([ \\t]+)(?=[a-zA-Z])'
     'contentName': 'keyword.control.robot'
@@ -82,4 +75,8 @@
         'name': 'entity.tag.name.robot'
       '1':
         'name': 'text.robot'
+  'keyword':
+    'begin': '\\=[ \\t]+'
+    'contentName': 'keyword.control.robot'
+    'end': '\\s{2,}|\\t|$'
 'scopeName': 'text.robot'

--- a/grammars/robottxt.cson
+++ b/grammars/robottxt.cson
@@ -19,7 +19,7 @@
     'include': '#comment'
   }
   {
-    'begin': '^(?![ \t\n\*\|])'
+    'begin': '^(?![ \\t\\n\\*\\|])'
     'contentName': 'keyword.control.robot'
     'end': '\\s{2,}|\\t|$'
     'patterns': [
@@ -28,6 +28,26 @@
       }
     ]
   }
+  {
+    'begin': '^([ \\t]+)\\$\\{.+?\\=([ \\t]+)'
+    'contentName': 'keyword.control.robot'
+    'end': '\\s{2,}|\\t|$'
+    'patterns': [
+      {
+        'include': '#variables'
+      }
+    ]
+  }  
+  {
+    'begin': '^([ \\t]+)(?=[a-zA-Z])'
+    'contentName': 'keyword.control.robot'
+    'end': '\\s{2,}|\\t|$'
+    'patterns': [
+      {
+        'include': '#variables'
+      }
+    ]
+  }  
   {
     'match': '(?:^[\\s\\t]+)(Given|When|And|Then|But)'
     'captures':

--- a/spec/robot-framework-spec.coffee
+++ b/spec/robot-framework-spec.coffee
@@ -33,14 +33,20 @@ describe 'Robot Framework grammar', ->
 
       expect(tokens[0].value).toEqual '# Test Case'
       expect(tokens[0].scopes).toEqual ['text.robot', 'comment.line.robot']
-      expect(tokens[1].value).toEqual '\n    Step'
-      expect(tokens[1].scopes).toEqual ['text.robot']
+      expect(tokens[1].value).toEqual '\n'
+      expect(tokens[2].value).toEqual '    '
+      expect(tokens[3]).value).toEqual 'Step'
+      expect(tokens[3].scopes).toEqual ['keyword.control.robot']
 
     it 'does not tokenizes comment', ->
       {tokens} = grammar.tokenizeLine '    This is step    #id'
 
-      expect(tokens[0].value).toEqual '    This is step    #id'
-      expect(tokens[0].scopes).toEqual ['text.robot']
+      expect(tokens[0].value).toEqual '    '
+      expect(tokens[1].value).toEqual 'This is step'
+      expect(tokens[1].scopes).toEqual ['keyword.control.robot']
+      expect(tokens[2].value).toEqual '    '
+      expect(tokens[3].value).toEqual '#d'
+      expect(tokens[3].scopes).toEqual ['text.robot']
 
   describe 'variable', ->
 

--- a/spec/robot-framework-spec.coffee
+++ b/spec/robot-framework-spec.coffee
@@ -36,16 +36,16 @@ describe 'Robot Framework grammar', ->
       expect(tokens[1].value).toEqual '\n'
       expect(tokens[2].value).toEqual '    '
       expect(tokens[3].value).toEqual 'Step'
-      expect(tokens[3].scopes).toEqual ['keyword.control.robot']
+      expect(tokens[3].scopes).toEqual ['text.robot', 'keyword.control.robot']
 
     it 'does not tokenizes comment', ->
       {tokens} = grammar.tokenizeLine '    This is step    #id'
 
       expect(tokens[0].value).toEqual '    '
       expect(tokens[1].value).toEqual 'This is step'
-      expect(tokens[1].scopes).toEqual ['keyword.control.robot']
+      expect(tokens[1].scopes).toEqual ['text.robot', 'keyword.control.robot']
       expect(tokens[2].value).toEqual '    '
-      expect(tokens[3].value).toEqual '#d'
+      expect(tokens[3].value).toEqual '#id'
       expect(tokens[3].scopes).toEqual ['text.robot']
 
   describe 'variable', ->

--- a/spec/robot-framework-spec.coffee
+++ b/spec/robot-framework-spec.coffee
@@ -35,7 +35,7 @@ describe 'Robot Framework grammar', ->
       expect(tokens[0].scopes).toEqual ['text.robot', 'comment.line.robot']
       expect(tokens[1].value).toEqual '\n'
       expect(tokens[2].value).toEqual '    '
-      expect(tokens[3]).value).toEqual 'Step'
+      expect(tokens[3].value).toEqual 'Step'
       expect(tokens[3].scopes).toEqual ['keyword.control.robot']
 
     it 'does not tokenizes comment', ->

--- a/spec/robot-framework-spec.coffee
+++ b/spec/robot-framework-spec.coffee
@@ -110,31 +110,31 @@ describe 'Robot Framework grammar', ->
       {tokens} = grammar.tokenizeLine '    Given Do Something'
 
       expect(tokens[1].scopes).toEqual expectedScopes
-      expect(tokens[1].value).toEqual 'Given'
+      expect(tokens[1].value).toEqual 'Given Do Something'
 
     it 'tokenizes When', ->
       {tokens} = grammar.tokenizeLine '    When Do Something'
 
       expect(tokens[1].scopes).toEqual expectedScopes
-      expect(tokens[1].value).toEqual 'When'
+      expect(tokens[1].value).toEqual 'When Do Something'
 
     it 'tokenizes Then', ->
       {tokens} = grammar.tokenizeLine '    Then Do Something'
 
       expect(tokens[1].scopes).toEqual expectedScopes
-      expect(tokens[1].value).toEqual 'Then'
+      expect(tokens[1].value).toEqual 'Then Do Something'
 
     it 'tokenizes And', ->
       {tokens} = grammar.tokenizeLine '    And Do Something'
 
       expect(tokens[1].scopes).toEqual expectedScopes
-      expect(tokens[1].value).toEqual 'And'
+      expect(tokens[1].value).toEqual 'And Do Something'
 
     it 'tokenizes But', ->
       {tokens} = grammar.tokenizeLine '    But Do Something'
 
       expect(tokens[1].scopes).toEqual expectedScopes
-      expect(tokens[1].value).toEqual 'But'
+      expect(tokens[1].value).toEqual 'But Do Something'
 
     describe 'issue 12', ->
 

--- a/spec/robot-framework-spec.coffee
+++ b/spec/robot-framework-spec.coffee
@@ -138,11 +138,11 @@ describe 'Robot Framework grammar', ->
 
     describe 'issue 12', ->
 
-      it "should tokenizes 'And' when it isn't at the start of a keyword", ->
+      it "should not tokenize 'And' when it isn't at the start of a keyword", ->
         {tokens} = grammar.tokenizeLine '    Press And Hold The Button'
 
-        expect(tokens.length).toEqual 1
-        expect(tokens[0].value).toEqual '    Press And Hold The Button'
+        expect(tokens.length).toEqual 2
+        expect(tokens[1].value).toEqual 'Press And Hold The Button'
 
   describe 'testcase', ->
 

--- a/spec/robot-framework-spec.coffee
+++ b/spec/robot-framework-spec.coffee
@@ -209,9 +209,9 @@ describe 'Robot Framework grammar', ->
 
     it 'does not tokenizes css selector', ->
       {tokens} = grammar.tokenizeLine '  Somebody  css=input[name=value]'
-      expect(tokens.length).toEqual(1)
-      expect(tokens[0].value).toEqual '  Somebody  css=input[name=value]'
-      expect(tokens[0].scopes).toEqual ['text.robot']
+      expect(tokens.length).toEqual(4)
+      expect(tokens[3].value).toEqual 'css=input[name=value]'
+      expect(tokens[3].scopes).toEqual ['text.robot']
 
   grammarTest(
     path.join(__dirname, "fixtures", "test_separate_keyword_and_value.robot"))


### PR DESCRIPTION
To improve the syntax highlighting of keywords. 
I hope this will resolve the following feature request: https://github.com/wingyplus/language-robot-framework/issues/37

How: I added two regex in robottxt.cson and gave them 'keyword.control.robot' scope.

![image](https://user-images.githubusercontent.com/4479000/45013254-ccd8af80-b05d-11e8-92a4-8a002dae25ae.png)
