### PR TITLE
Add .resource as an appropriate filetype extension

### DIFF
--- a/grammars/robottxt.cson
+++ b/grammars/robottxt.cson
@@ -1,6 +1,7 @@
 'comment': '\n\tRobot Framework syntax highlighting for txt format.\t\n\t'
 'fileTypes': [
-  'robot'
+  'robot',
+  'resource'
 ]
 'name': 'Robot Framework'
 'firstLineMatch': '\\*{3} (?i:Settings|Keywords|Variables|Test Cases) \\*{3}'


### PR DESCRIPTION
Since `.resource` is recognized officially by robot this should be accepted here too.

http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#resource-and-variable-files

Signed-off-by: Corbin Weidner <corbin.weidner@gtri.gatech.edu>